### PR TITLE
feat: revamp landing page with scroll-triggered npm install terminal

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -13,10 +13,11 @@ export function Navbar() {
 
   return (
     <header>
-      <div className="flex gap-3 justify-center">
-        <div className="flex items-center border dark:border-white border-black shadow-lg rounded-full px-4 py-2 m-3 gap-3">
-          <p>indrakoslab</p>
-          <span>|</span>
+      {/* Desktop: top center | Mobile: fixed bottom center */}
+      <div className="fixed bottom-4 left-0 right-0 z-50 flex justify-center md:static md:bottom-auto md:mt-0">
+        <div className="flex items-center border dark:border-white border-black shadow-lg rounded-full px-4 py-2 m-3 gap-3 bg-background/80 backdrop-blur-sm">
+          <p className="font-medium">indrakoslab</p>
+          <span className="text-muted-foreground">|</span>
           <nav>
             <ul className="flex flex-row gap-6">
               <li>
@@ -29,7 +30,7 @@ export function Navbar() {
               </li>
             </ul>
           </nav>
-          <span>|</span>
+          <span className="text-muted-foreground">|</span>
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/npm-install-terminal.tsx
+++ b/src/components/npm-install-terminal.tsx
@@ -1,0 +1,327 @@
+import { useState, useEffect, useCallback } from "react";
+import { useInView } from "@/hooks/use-in-view";
+
+interface Experience {
+  company: string;
+  role: string | string[];
+  startDate: string;
+  endDate: string;
+}
+
+interface MainStack {
+  lang: string[];
+  "meta-framework": string;
+  db: string[];
+  orm: string[];
+  style: string[];
+  server: string;
+  tooling: string[];
+}
+
+interface SecondaryStack {
+  lang: string;
+  "meta-framework": string;
+  server: string[];
+}
+
+export interface NpmInstallTerminalProps {
+  profile: {
+    name: string;
+    github: string;
+    experiences: Experience[];
+  };
+  mainStack: MainStack;
+  secondaryStack: SecondaryStack;
+}
+
+type Phase = "idle" | "typing" | "loading" | "revealed";
+
+const COMMAND = "npm install indra-putra";
+const TYPING_SPEED = 60;
+const LOADING_DURATION = 1500;
+
+export function NpmInstallTerminal({
+  profile,
+  mainStack,
+  secondaryStack,
+}: NpmInstallTerminalProps) {
+  const [ref, isInView] = useInView({ threshold: 0.2 });
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [typedChars, setTypedChars] = useState(0);
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setReducedMotion(true);
+      setPhase("revealed");
+      setTypedChars(COMMAND.length);
+    }
+  }, []);
+
+  // Start typing when in view
+  useEffect(() => {
+    if (isInView && phase === "idle" && !reducedMotion) {
+      setPhase("typing");
+    }
+  }, [isInView, phase, reducedMotion]);
+
+  // Typing animation
+  useEffect(() => {
+    if (phase !== "typing") return;
+
+    if (typedChars < COMMAND.length) {
+      const timeout = setTimeout(() => {
+        setTypedChars((c) => c + 1);
+      }, TYPING_SPEED);
+      return () => clearTimeout(timeout);
+    }
+
+    // Typing done, move to loading
+    const pause = setTimeout(() => setPhase("loading"), 300);
+    return () => clearTimeout(pause);
+  }, [phase, typedChars]);
+
+  // Loading phase
+  useEffect(() => {
+    if (phase !== "loading") return;
+
+    const timeout = setTimeout(() => setPhase("revealed"), LOADING_DURATION);
+    return () => clearTimeout(timeout);
+  }, [phase]);
+
+  const formatDate = useCallback((date: string) => {
+    const parts = date.split(" ");
+    return parts[0].slice(0, 3) + " " + parts[1].slice(-2);
+  }, []);
+
+  const totalSkills = [
+    ...mainStack.lang,
+    mainStack["meta-framework"],
+    ...mainStack.db,
+    ...mainStack.orm,
+    ...mainStack.style,
+    mainStack.server,
+    ...mainStack.tooling,
+  ].length;
+
+  const dependencies: Record<string, string> = {};
+  for (const lang of mainStack.lang)
+    dependencies[lang.toLowerCase()] =
+      lang === "Javascript" ? '"^ES2024"' : '"^5.x"';
+  dependencies[mainStack["meta-framework"].toLowerCase()] = '"latest"';
+  for (const style of mainStack.style)
+    dependencies[style.toLowerCase()] =
+      style === "TailwindCSS" ? '"^4.x"' : '"latest"';
+  for (const db of mainStack.db)
+    dependencies[db.toLowerCase()] =
+      db === "PostgreSQL" ? '"^16"' : '"latest"';
+  for (const orm of mainStack.orm)
+    dependencies[orm.toLowerCase()] = '"latest"';
+  dependencies[mainStack.server.toLowerCase()] = '"^4.x"';
+
+  const peerDeps: Record<string, string> = {
+    [secondaryStack.lang.toLowerCase()]: '"^8.x"',
+    [secondaryStack["meta-framework"].toLowerCase()]: '"^10.x"',
+  };
+  for (const s of secondaryStack.server) {
+    peerDeps[s.toLowerCase()] = '"latest"';
+  }
+
+  return (
+    <div ref={ref} className="w-full max-w-3xl mx-auto">
+      {/* Terminal window */}
+      <div className="rounded-lg overflow-hidden shadow-2xl border border-[#313244]">
+        {/* Title bar */}
+        <div className="flex items-center gap-2 px-4 py-3 bg-[#181825]">
+          <span className="w-3 h-3 rounded-full bg-[#f38ba8]" />
+          <span className="w-3 h-3 rounded-full bg-[#f9e2af]" />
+          <span className="w-3 h-3 rounded-full bg-[#a6e3a1]" />
+          <span className="ml-2 text-xs text-[#6c7086] font-mono">
+            indra@dev ~ zsh
+          </span>
+        </div>
+
+        {/* Terminal body */}
+        <div className="bg-[#1e1e2e] p-4 md:p-6 font-mono text-sm md:text-base min-h-[200px]">
+          {/* Command line */}
+          <div className="flex flex-wrap">
+            <span className="text-[#a6e3a1]">$</span>
+            <span className="ml-2 text-[#cdd6f4]">
+              {COMMAND.slice(0, typedChars)}
+            </span>
+            {phase === "idle" || phase === "typing" ? (
+              <span className="animate-blink text-[#cdd6f4]">▌</span>
+            ) : null}
+          </div>
+
+          {/* Loading phase */}
+          {(phase === "loading" || phase === "revealed") && (
+            <div className="mt-4">
+              {phase === "loading" && (
+                <>
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 h-2 bg-[#313244] rounded-full overflow-hidden">
+                      <div className="h-full bg-[#a6e3a1] rounded-full animate-progress" />
+                    </div>
+                  </div>
+                  <p className="text-[#6c7086] text-xs mt-1">
+                    resolving dependencies...
+                  </p>
+                </>
+              )}
+
+              {/* Revealed content */}
+              {phase === "revealed" && (
+                <div className="animate-fade-in">
+                  <p className="text-[#a6e3a1]">+ indra-putra@5.0.0</p>
+
+                  {/* Package card */}
+                  <div className="mt-4 border border-[#313244] rounded-md p-4 md:p-5">
+                    <p className="text-[#cba6f7] font-bold text-base md:text-lg">
+                      indra-putra{" "}
+                      <span className="text-[#6c7086] font-normal text-sm">
+                        v5.0.0
+                      </span>
+                    </p>
+                    <p className="text-[#6c7086] text-xs mt-1">
+                      &quot;Fullstack Developer based in Singapore&quot;
+                    </p>
+
+                    <div className="mt-4 space-y-1 text-xs md:text-sm">
+                      <Line label="homepage" value="github.com/indraakkk" />
+                      <Line label="license" value="Open to Opportunities" />
+                      <Line
+                        label="maintained"
+                        value="✓ actively"
+                        valueClass="text-[#a6e3a1]"
+                      />
+                    </div>
+
+                    {/* Dependencies */}
+                    <div className="mt-4">
+                      <p className="text-[#f9e2af] text-xs md:text-sm">
+                        dependencies &#123;
+                      </p>
+                      <div className="pl-4 space-y-0.5 mt-1">
+                        {Object.entries(dependencies).map(([name, ver]) => (
+                          <p
+                            key={name}
+                            className="text-xs md:text-sm text-[#cdd6f4]"
+                          >
+                            <span className="text-[#89b4fa]">
+                              &quot;{name}&quot;
+                            </span>
+                            <span className="text-[#6c7086]"> : </span>
+                            <span className="text-[#a6e3a1]">{ver}</span>
+                          </p>
+                        ))}
+                      </div>
+                      <p className="text-[#f9e2af] text-xs md:text-sm mt-1">
+                        &#125;
+                      </p>
+                    </div>
+
+                    {/* Peer Dependencies */}
+                    <div className="mt-3">
+                      <p className="text-[#f9e2af] text-xs md:text-sm">
+                        peerDependencies &#123;
+                      </p>
+                      <div className="pl-4 space-y-0.5 mt-1">
+                        {Object.entries(peerDeps).map(([name, ver]) => (
+                          <p
+                            key={name}
+                            className="text-xs md:text-sm text-[#cdd6f4]"
+                          >
+                            <span className="text-[#89b4fa]">
+                              &quot;{name}&quot;
+                            </span>
+                            <span className="text-[#6c7086]"> : </span>
+                            <span className="text-[#a6e3a1]">{ver}</span>
+                          </p>
+                        ))}
+                      </div>
+                      <p className="text-[#f9e2af] text-xs md:text-sm mt-1">
+                        &#125;
+                      </p>
+                    </div>
+
+                    {/* Changelog */}
+                    <div className="mt-3">
+                      <p className="text-[#f9e2af] text-xs md:text-sm">
+                        changelog &#123;
+                      </p>
+                      <div className="pl-4 space-y-0.5 mt-1">
+                        {profile.experiences.map((exp, i) => {
+                          const version = `${5 - i}.0`;
+                          const role = Array.isArray(exp.role)
+                            ? exp.role[0]
+                            : exp.role;
+                          return (
+                            <p
+                              key={exp.company}
+                              className="text-xs md:text-sm text-[#cdd6f4]"
+                            >
+                              <span className="text-[#cba6f7]">{version}</span>
+                              <span className="text-[#6c7086]"> </span>
+                              <span>
+                                {exp.company} &mdash; {role.split(" ")[0]}
+                              </span>
+                              <span className="text-[#6c7086] ml-2">
+                                {formatDate(exp.startDate)} &ndash;{" "}
+                                {formatDate(exp.endDate)}
+                              </span>
+                            </p>
+                          );
+                        })}
+                      </div>
+                      <p className="text-[#f9e2af] text-xs md:text-sm mt-1">
+                        &#125;
+                      </p>
+                    </div>
+
+                    {/* Summary stats */}
+                    <div className="mt-4 space-y-0.5 text-xs md:text-sm">
+                      <p className="text-[#a6e3a1]">
+                        ✓ {totalSkills} skills installed
+                      </p>
+                      <p className="text-[#a6e3a1]">
+                        ✓ {profile.experiences.length} companies contributed to
+                      </p>
+                      <p className="text-[#a6e3a1]">✓ 0 vulnerabilities</p>
+                    </div>
+                  </div>
+
+                  {/* Final prompt */}
+                  <div className="mt-4 flex">
+                    <span className="text-[#a6e3a1]">$</span>
+                    <span className="ml-2 animate-blink text-[#cdd6f4]">
+                      ▌
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Line({
+  label,
+  value,
+  valueClass = "text-[#cdd6f4]",
+}: {
+  label: string;
+  value: string;
+  valueClass?: string;
+}) {
+  return (
+    <p className="text-[#cdd6f4]">
+      <span className="text-[#6c7086]">{label.padEnd(12)}</span>
+      <span className="text-[#6c7086]">: </span>
+      <span className={valueClass}>{value}</span>
+    </p>
+  );
+}

--- a/src/hooks/use-in-view.ts
+++ b/src/hooks/use-in-view.ts
@@ -1,0 +1,36 @@
+import { useRef, useState, useEffect } from "react";
+
+export function useInView(options?: {
+  threshold?: number;
+  triggerOnce?: boolean;
+}) {
+  const { threshold = 0.3, triggerOnce = true } = options ?? {};
+  const ref = useRef<HTMLDivElement>(null);
+  const [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    // Skip animation for users who prefer reduced motion
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setIsInView(true);
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true);
+          if (triggerOnce) observer.disconnect();
+        }
+      },
+      { threshold },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold, triggerOnce]);
+
+  return [ref, isInView] as const;
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,7 +4,7 @@ import {
   HeadContent,
   Scripts,
 } from "@tanstack/react-router";
-import { Heart } from "lucide-react";
+import { Heart, Github } from "lucide-react";
 import { Navbar } from "@/components/navbar";
 import { ThemeProvider } from "@/components/theme-provider";
 import { getTheme } from "@/lib/theme";
@@ -54,10 +54,21 @@ function RootComponent() {
       <main>
         <Outlet />
       </main>
-      <footer className="flex justify-center py-10">
-        <span className="flex items-center">
-          Made with <Heart className="w-4 h-4 mx-3" /> from SUB
+      <footer className="flex flex-col items-center gap-3 py-10 pb-24 md:pb-10">
+        <span className="flex items-center text-sm text-muted-foreground">
+          Made with <Heart className="w-4 h-4 mx-2" /> from SUB
         </span>
+        <div className="flex gap-4">
+          <a
+            href="https://github.com/indraakkk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="GitHub"
+          >
+            <Github className="w-4 h-4" />
+          </a>
+        </div>
       </footer>
     </div>
   );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,70 +1,55 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState, lazy, Suspense } from "react";
-import { PlugZap, Braces } from "lucide-react";
+import { Github, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  NpmInstallTerminal,
+  type NpmInstallTerminalProps,
+} from "@/components/npm-install-terminal";
 
-const EditorMonaco = lazy(() =>
-  import("@/components/editor-monaco").then((m) => ({
-    default: m.EditorMonaco,
-  })),
-);
+const BLOG_URL =
+  import.meta.env.PROD
+    ? "https://indrakoslab-blog.vercel.app"
+    : "http://localhost:3001";
 
-const masterData = {
-  profile: `{
-  "name": "Indra Putra",
-  "github": "indraakkk",
-  "experiences": [
+const profileData: NpmInstallTerminalProps["profile"] = {
+  name: "Indra Putra",
+  github: "indraakkk",
+  experiences: [
     {
-      "company": "A Life By Design",
-      "role": "Software Developer",
-      "startDate": "August 2023",
-      "endDate": "January 2024",
-      "description": "Contributed actively to a 4-day inception meeting, fostering a collaborative environment for ideation in kickstarting an ecommerce ecosystem. Implemented agile methodologies and functioned as a Scrum Master within a team of three developers. Translated designs into highly maintainable and scalable code, maintaining a commitment to thorough local testing. I follow coding best practice and based on code standard"
+      company: "A Life By Design",
+      role: "Software Developer",
+      startDate: "August 2023",
+      endDate: "January 2024",
     },
     {
-      "company": "CPR Vision",
-      "role": "Software Developer",
-      "startDate": "October 2022",
-      "endDate": "August 2023",
-      "description": "Building multiple websites for clients seasonal campaigns to highlight the product's unique selling points and engage with customers."
+      company: "CPR Vision",
+      role: "Software Developer",
+      startDate: "October 2022",
+      endDate: "August 2023",
     },
     {
-      "company": "Others",
-      "role": ["Full-stack Developer", "Backend Developer"],
-      "startDate": "October 2018",
-      "endDate": "September 2022",
-      "description": "Gained experience in diverse projects across various industries and companies. Examples include Chatbot, B2B Marketplace, Logistics, and Payment Gateway development."
-    }
-  ]
-}`,
-  mainStack: `{
-  "lang": ["Javascript", "Typescript"],
+      company: "Others",
+      role: ["Full-stack Developer", "Backend Developer"],
+      startDate: "October 2018",
+      endDate: "September 2022",
+    },
+  ],
+};
+
+const mainStackData: NpmInstallTerminalProps["mainStack"] = {
+  lang: ["Javascript", "Typescript"],
   "meta-framework": "NextJs",
-  "db": ["MySQL", "MariaDB", "PostgreSQL", "SQLite", "MongoDB"],
-  "orm": ["DrizzleORM", "Prisma"],
-  "style": ["TailwindCSS", "CSS"],
-  "server": "ExpressJs",
-  "tooling": ["pnpm", "bunJs", "NodeJs"]
-}`,
-  secondaryStack: `{
-  "lang": "PHP",
+  db: ["MySQL", "MariaDB", "PostgreSQL", "SQLite", "MongoDB"],
+  orm: ["DrizzleORM", "Prisma"],
+  style: ["TailwindCSS", "CSS"],
+  server: "ExpressJs",
+  tooling: ["pnpm", "bunJs", "NodeJs"],
+};
+
+const secondaryStackData: NpmInstallTerminalProps["secondaryStack"] = {
+  lang: "PHP",
   "meta-framework": "Laravel",
-  "server": ["Lumen", "SlimPHP"]
-}`,
-} as const;
-
-const fileNames = [
-  "profile.json",
-  "main-stack.json",
-  "secondary-stack.json",
-] as const;
-
-type TabKey = "profile" | "mainStack" | "secondaryStack";
-
-const tabKeyMap: Record<(typeof fileNames)[number], TabKey> = {
-  "profile.json": "profile",
-  "main-stack.json": "mainStack",
-  "secondary-stack.json": "secondaryStack",
+  server: ["Lumen", "SlimPHP"],
 };
 
 export const Route = createFileRoute("/")({
@@ -72,54 +57,53 @@ export const Route = createFileRoute("/")({
 });
 
 function HomePage() {
-  const [selectedTab, setSelectedTab] =
-    useState<(typeof fileNames)[number]>("profile.json");
-  const text = masterData[tabKeyMap[selectedTab]];
+  const scrollToWork = () => {
+    document.getElementById("my-work")?.scrollIntoView({ behavior: "smooth" });
+  };
 
   return (
-    <div className="container mx-auto px-4 md:px-8">
-      <div className="min-h-full flex flex-col md:flex-row items-center justify-center gap-3">
-        <div className="flex flex-col gap-6 w-full md:w-1/2">
-          <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold text-balance">
-            Hi, I am Fullstack Developer
+    <div>
+      {/* Hero Section */}
+      <section className="min-h-[calc(100svh-80px)] flex items-center justify-center px-4 md:px-8">
+        <div className="flex flex-col items-center text-center gap-6 max-w-2xl">
+          <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight text-balance">
+            Hey, I'm Indra Putra
           </h1>
-          <span className="text-balance">
-            I'm frontend-leaning software developer with 5 years of experience,
-            have worked for multiple companies based in Singapore. I'm passionate
-            to translate designs into code for web development, ensuring
-            high-quality results withing specific timelines.
-          </span>
-        </div>
-        <div className="flex flex-col w-full md:w-1/2 h-fit rounded-lg border dark:border-white">
-          <div className="w-full flex overflow-x-auto scroll-hidden">
-            {fileNames.map((fn, index) => (
-              <Button
-                key={fn}
-                variant="ghost"
-                className={`flex items-center gap-1 rounded-none ${
-                  fn === selectedTab ? "bg-accent" : ""
-                } ${index === 0 ? "rounded-tl-md" : ""}`}
-                onClick={() => setSelectedTab(fn)}
-              >
-                <Braces className="w-4 h-4" />
-                {fn}
-              </Button>
-            ))}
+          <p className="text-lg md:text-xl text-muted-foreground max-w-lg text-balance">
+            Fullstack Developer based in Singapore with 5+ years of experience
+            building for the web.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 mt-2">
+            <Button size="lg" onClick={scrollToWork}>
+              View My Work
+            </Button>
+            <Button variant="outline" size="lg" asChild>
+              <a href={BLOG_URL} target="_blank" rel="noopener noreferrer">
+                Read My Blog
+                <ArrowRight className="w-4 h-4 ml-1" />
+              </a>
+            </Button>
           </div>
-          <Suspense
-            fallback={
-              <div className="w-full min-h-[500px] flex items-center justify-center text-muted-foreground">
-                Loading editor...
-              </div>
-            }
+          <a
+            href="https://github.com/indraakkk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground transition-colors mt-2"
+            aria-label="GitHub profile"
           >
-            <EditorMonaco value={text} className="w-full min-h-[500px]" />
-          </Suspense>
-          <div>
-            <PlugZap className="w-5 h-5 m-1 opacity-50" />
-          </div>
+            <Github className="w-5 h-5" />
+          </a>
         </div>
-      </div>
+      </section>
+
+      {/* Terminal Section */}
+      <section id="my-work" className="py-16 md:py-24 px-4 md:px-8">
+        <NpmInstallTerminal
+          profile={profileData}
+          mainStack={mainStackData}
+          secondaryStack={secondaryStackData}
+        />
+      </section>
     </div>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -102,3 +102,54 @@
 .scroll-hidden::-webkit-scrollbar {
   display: none;
 }
+
+/* Terminal animations */
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+@keyframes progress-fill {
+  from { width: 0%; }
+  to { width: 100%; }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-blink {
+  animation: blink 1s step-end infinite;
+}
+
+.animate-progress {
+  animation: progress-fill 1.5s ease-in-out forwards;
+}
+
+.animate-fade-in {
+  animation: fade-in 300ms ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-blink,
+  .animate-progress,
+  .animate-fade-in {
+    animation: none !important;
+  }
+
+  .animate-progress {
+    width: 100% !important;
+  }
+
+  .animate-fade-in {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Replace the Monaco editor landing page with a two-section layout:
- Hero section (centered, full viewport height) with CTAs and social links
- Scroll-triggered "npm install indra-putra" terminal animation that
  reveals profile, tech stack, experience, and stats as a package card

Also: navbar floats at bottom on mobile, enhanced footer with GitHub link,
added CSS animation keyframes with prefers-reduced-motion support.

https://claude.ai/code/session_01FjnG2gQYJqWHJV4WsRHf69